### PR TITLE
Update access.inc.php

### DIFF
--- a/access.inc.php
+++ b/access.inc.php
@@ -31,6 +31,7 @@ define('PATTERN_ECONT',				'/^(1)[0-9]{12}$/') ;
 define('PATTERN_A1POST',			'/^(UR|LY|RS)[0-9]{9}(DE)$/') ;
 define('PATTERN_LEOEXPRES',		'/^(6|7)[0-9]{7}$/') ;
 define('PATTERN_CVC',		      '/^[0]{2}(09|10)[0-9]{4}$/') ;
+define('PATTERN_BGPOST',			'/^(CP|PS|RS|RI)[0-9]{9}(BG)$/') ;
 
 /* ************************************************************************* */
 /*
@@ -44,5 +45,10 @@ A1 Post uses UPU format (XX123456789YY)
 Leo Expres uses 8-digit tracking numbers; the first one is either a 6 or a 7
 CVC uses uses 8-digit tracking numbers; we presume they increase linearly and
 are currently in the 90,000 — 100,000 range.
+BG Post uses UPU format as well
+	??: No tracking provided
+	RI: Tracking provided, no signature on delivery (?)
+	RS: Tracking provided, require signature on delivery (?)
+	Trailing marker is always BG
 */
 /* ************************************************************************* */


### PR DESCRIPTION
Adding provisional support for Bulgarian Post tracking numbers.
According to initial research, there are four kinds of active prefixes: CP, PS, RS and RI. Might be more.